### PR TITLE
More docstrings and literate-style comments

### DIFF
--- a/box.js
+++ b/box.js
@@ -5,6 +5,16 @@
 'use strict';
 
 module.exports = function Box(description) {
+  /**
+  Create a "boxed" value.
+  Boxed values may be used as flags to signify a mode or value.
+  This is similar to the way some languages use magic constants to trigger
+  a specific behavior or mode.
+
+  Boxed values may have a description that explains how they are to be used.
+  
+  Returns a box object.
+  **/
   description = description || 'Boxed value'
   return function box(value) {
     return {

--- a/browser/http.js
+++ b/browser/http.js
@@ -155,16 +155,34 @@ connect.define(String, function(uri) { return connect(request({ uri: uri })) })
 exports.connect = connect
 
 function readHead(request) {
+  /** 
+  Read the head data for a single request.
+  Returns a reducible.
+  **/
   return take(connect(request), 1)
 }
 exports.readHead = readHead
 
 function readHeaders(request) {
+  /**
+  Read the headers for a single request.
+  Returns a reducible.
+  **/
   return map(readHead(request), function(head) { return head.headers })
 }
 exports.readHeaders = readHeaders
 
 function read(request) {
+  /**
+  Read the request body for a single request.
+  Returns a reducible.
+
+  Example:
+
+      var body = http.read('http://example.com');
+      reduce(body, writeBodyToDOM);
+      
+  **/
   return drop(connect(request), 1)
 }
 exports.read = read

--- a/buffer.js
+++ b/buffer.js
@@ -53,8 +53,13 @@ function buffer(source) {
   return self
 }
 buffer.accumulate = function(buffer, next, initial) {
+  // If buffer has already been drained accumulate from the original source.
   if (isDrained(buffer)) return accumulate(buffer[input], next, initial)
+  // Otherwise, drain the buffer, passing items to the accumulating function.
   buffer[state] = drain(buffer, next, initial)
+  // Overshadow forward function, insuring that
+  // future values are not buffered, and are instead passed directly to the
+  // accumulation function.
   buffer[forward] = next
   return buffer
 }

--- a/buffer.js
+++ b/buffer.js
@@ -27,6 +27,19 @@ function isDrained(buffer) {
 }
 
 function buffer(source) {
+  /**
+  Buffer a reducible, saving items from reducible in-memory until a consumer
+  reduces the buffer.
+
+  Reducibles are not required to expose a data container for the sequence they
+  represent, meaning items in the reducible may not be represented in-memory
+  at all. This is great for representing potentially infinite data structures
+  like "mouse clicks over time", or "data streamed from server". However,
+  sometimes it's important to reduce all items in the reducible, even if the
+  item was emitted at a point in the past. This is where buffer comes in handy.
+  It stores a backlog of previously emitted items in-memory until you're
+  ready to consume.
+  **/
   var self = convert(source, buffer.accumulate)
   self[state] = null
   self[input] = source

--- a/channel.js
+++ b/channel.js
@@ -9,6 +9,13 @@ var signal = require('./signal'),
     emit = signal.emit, close = signal.close
 
 function channel() {
+  /**
+  Return a channel -- a sequence of events over time that may be reduced by
+  one or more consumer functions.
+
+  Channels are `signals` that have been transformed by `hub`, allowing them
+  to be reduced more than once.
+  **/
   return hub(signal())
 }
 channel.enqueue = emit

--- a/core.js
+++ b/core.js
@@ -165,6 +165,9 @@ exports.tail = tail
 //
 
 function append1(left, right) {
+  /**
+  The reducing function for append (below). Not public.
+  **/
   return convert({}, function(self, next, initial) {
     accumulate(left, function(value, result) {
       return value && value.is === end ? accumulate(right, next, result) :

--- a/core.js
+++ b/core.js
@@ -16,7 +16,7 @@ var slice = Array.slice || unbind(Array.prototype.slice)
 var end = Box('end of the sequence')
 exports.end = end
 
-var accumulated = Box('Indicator that source has being accumulateed')
+var accumulated = Box('Indicator that source has been accumulated')
 exports.accumulated = accumulated
 
 var error = Box('error')

--- a/core.js
+++ b/core.js
@@ -183,6 +183,13 @@ function append(left, right, rest) {
 exports.append = append
 
 function capture(source, recover) {
+  /**
+  Capture any boxed errors that occur while reducing a given `source` and
+  `recover` reduction using the provided function.
+
+  Allows you to bake error handling and recovery into your reductions -- crucial
+  for live data sources like XHR or Sockets.
+  **/
   return convert(source, function(self, next, initial) {
     accumulate(source, function(value, result) {
       if (value && value.is === error) {

--- a/core.js
+++ b/core.js
@@ -50,6 +50,11 @@ function transformer(source, transform) {
 exports.transformer = transformer
 
 function convert(source, method) {
+  /**
+  Make a `source` object accumulatable by creating a prototypal copy and
+  implementing the `accumulate` protocol on it with the given `method`.
+  Returns an accumulatable/reducible object.
+  **/
   return accumulate.implement(create(source), method)
 }
 exports.convert = convert

--- a/core.js
+++ b/core.js
@@ -28,8 +28,10 @@ var accumulate = Method(function(self, next, start) {
 })
 exports.accumulate = accumulate
 
+// Implement accumulation for undefined and null values.
+// Reducing/accumulating a null value will pass the initial start value to
+// the accumulating function, then end.
 function accumulateEmpty(_, f, start) { f(end(), start) }
-
 accumulate.define(undefined, accumulateEmpty)
 accumulate.define(null, accumulateEmpty)
 

--- a/core.js
+++ b/core.js
@@ -174,8 +174,8 @@ function append1(left, right) {
 }
 function append(left, right, rest) {
   /**
-  Joins given `reducible`s into `reducible` of items
-  of all the `reducibles` preserving an order of items.
+  Concatenate multiple `reducible`s, returning a single `reducible` containing
+  all the items from the original `reducibles`, in order.
   **/
   return rest ? slice(arguments, 1).reduce(append1, left) :
                 append1(left, right)

--- a/core.js
+++ b/core.js
@@ -152,6 +152,10 @@ function dropWhile(source, predicate) {
 exports.dropWhile = dropWhile
 
 function tail(source) {
+  /**
+  Get the last value of a reducible.
+  Reduces a reducible to it's tailing value.
+  **/
   return drop(source, 1)
 }
 exports.tail = tail

--- a/core.js
+++ b/core.js
@@ -9,8 +9,9 @@ var create = Object.create
 var Method = require('method')
 var Box = require('./box')
 
-// Define a shortcut for `Array.prototype.slice.call`.
 var unbind = Function.call.bind(Function.bind, Function.call)
+
+// Define a shortcut for `Array.prototype.slice.call`.
 var slice = Array.slice || unbind(Array.prototype.slice)
 
 var end = Box('end of the sequence')

--- a/core.js
+++ b/core.js
@@ -113,7 +113,7 @@ exports.take = take
 
 function drop(source, n) {
   /**
-  Reduces given `reducible` to a firs `n` items.
+  Reduces given `reducible` to first `n` items.
   **/
   return transformer(source, function(source) {
     var count = n >= 0 ? n : 1

--- a/core.js
+++ b/core.js
@@ -35,6 +35,8 @@ function accumulateEmpty(_, f, start) { f(end(), start) }
 accumulate.define(undefined, accumulateEmpty)
 accumulate.define(null, accumulateEmpty)
 
+// Implement accumulation method for native arrays, making arrays compatible
+// with reducer methods and other reducible values.
 accumulate.define(Array, function(array, next, initial) {
   var state = initial, index = 0, count = array.length
   while (index < count) {

--- a/dom.js
+++ b/dom.js
@@ -11,10 +11,22 @@ var core = require('./core'),
     end = core.end
 
 function open(target, type, options) {
+  /**
+  Capture events on a DOM element, converting them to a reducible channel.
+  Returns a reducible channel.
+
+  ## Example
+
+      var allClicks = open(document.documentElement, 'click')
+      var clicksOnMyTarget = filter(allClicks, function (click) {
+        return click.target === myTarget
+      })
+  **/
   var capture = options && options.capture || false
   return convert({}, function(self, next, state) {
     function handler(event) {
       state = next(event, state)
+      //  When channel is marked as accumulated, remove event listener.
       if (state && state.is === accumulated) {
         if (target.removeEventListener)
           target.removeEventListener(type, handler, capture)

--- a/hub.js
+++ b/hub.js
@@ -53,6 +53,11 @@ function isOpen(hub) {
 }
 
 function hub(source) {
+  /**
+  Take a reducible `source`, such as a `signal` and return a reducible that can
+  be consumed by many reducers.
+  **/
+
   // If source is already a hub avoid just return.
   if (isHub(source)) return source
   var value = convert(source, hub.accumulate)

--- a/signal.js
+++ b/signal.js
@@ -49,8 +49,11 @@ accumulate.define(Signal, function(signal, next, initial) {
   return signal
 })
 
-// Implement emit protocol for Signal
 emit.define(Signal, function(signal, value) {
+  /**
+  Emit a new value for signal.
+  Throws an exception if the signal is not open for emitting.
+  **/
   if (isClosed(signal)) throw Error('Signal is already closed')
   if (!isOpen(signal)) throw Error('Signal is not open')
   var result = signal[accumulator](value, signal[state])
@@ -63,6 +66,10 @@ emit.define(Signal, function(signal, value) {
 })
 
 close.define(Signal, function(signal, value) {
+  /**
+  Close a signal, preventing new values from being emitted.
+  Throws an exception if the signal is already closed.
+  **/
   if (isClosed(signal)) throw Error('Signal is already closed')
   if (value !== undefined) emit(signal, value)
   var result = signal[state]

--- a/signal.js
+++ b/signal.js
@@ -31,13 +31,18 @@ function isOpen(signal) {
 }
 
 function Signal() {}
+
+// Implement accumulate protocol on signals, making them reducible.
 accumulate.define(Signal, function(signal, next, initial) {
+  // Signals may only be reduced by one consumer function.
+  // Other data types built on top of signal may allow for more consumers.
   if (isOpen(signal)) throw Error('Signal is being consumed')
   if (isClosed(signal)) return next(end(), initial)
   signal[accumulator] = next
   signal[state] = initial
   return signal
 })
+
 emit.define(Signal, function(signal, value) {
   if (isClosed(signal)) throw Error('Signal is already closed')
   if (!isOpen(signal)) throw Error('Signal is not open')
@@ -49,6 +54,7 @@ emit.define(Signal, function(signal, value) {
   }
   return signal
 })
+
 close.define(Signal, function(signal, value) {
   if (isClosed(signal)) throw Error('Signal is already closed')
   if (value !== undefined) emit(signal, value)

--- a/signal.js
+++ b/signal.js
@@ -19,6 +19,14 @@ var accumulator = Name()
 var state = Name()
 var closed = Name()
 
+// Define a `Signal` data-type. A signal is a sequence of "events over time".
+// If you're familiar with libraries like Node EventEmitter, you might have
+// an easy time thinking of Signal as a single event channel. The key difference
+// is that signal represents events-over-time as a reducible value. This means
+// the events-over-time can be transformed, filtered forked and joined just like
+// an array.
+function Signal() {}
+
 // Signals can be either open or closed. An open signal may `emit` new values.
 // A signal that is not open may not emit.
 // 
@@ -29,8 +37,6 @@ function isClosed(signal) {
 function isOpen(signal) {
   return !!signal[accumulator]
 }
-
-function Signal() {}
 
 // Implement accumulate protocol on signals, making them reducible.
 accumulate.define(Signal, function(signal, next, initial) {
@@ -43,6 +49,7 @@ accumulate.define(Signal, function(signal, next, initial) {
   return signal
 })
 
+// Implement emit protocol for Signal
 emit.define(Signal, function(signal, value) {
   if (isClosed(signal)) throw Error('Signal is already closed')
   if (!isOpen(signal)) throw Error('Signal is not open')

--- a/signal.js
+++ b/signal.js
@@ -19,6 +19,10 @@ var accumulator = Name()
 var state = Name()
 var closed = Name()
 
+// Signals can be either open or closed. An open signal may `emit` new values.
+// A signal that is not open may not emit.
+// 
+// Define helper that allow you to test the state of a signal.
 function isClosed(signal) {
   return !!signal[closed]
 }
@@ -58,6 +62,9 @@ close.define(Signal, function(signal, value) {
   return signal
 })
 
+// Define a factory function for the `Signal` constructor.
+// Assign other signal functions to the factory function object and export
+// the result.
 function signal() { return new Signal() }
 signal.type = Signal
 signal.isOpen = isOpen

--- a/signal.js
+++ b/signal.js
@@ -20,6 +20,9 @@ var state = Name()
 var closed = Name()
 
 // Define a `Signal` data-type. A signal is a sequence of "events over time".
+// 
+// Signals are a building block for creating Reactive event-driven programs.
+// 
 // If you're familiar with libraries like Node EventEmitter, you might have
 // an easy time thinking of Signal as a single event channel. The key difference
 // is that signal represents events-over-time as a reducible value. This means


### PR DESCRIPTION
Reducers are really interesting, but I've had some trouble figuring out how all the pieces fit together. I think this is why:
- Functional libraries are composed of granular functions. This means everything is re-usable. It also means there is not a clear distinction between API and internal functions, as you get with OOP. This makes it harder to understand how to fit the pieces together for your app.
- Single-verb functions are expressive when writing code but not descriptive when reading the library. Without comments, in order to understand a function you must understand the internals of all the functions from which it is composed.

All this to say, I want to help out by adding docstrings and literate-style comments. `comments` branch is based on browser branch, which seems to be the most up-to-date.
