### PR TITLE
Simplified http lib and removed url library dependency.

### DIFF
--- a/browser/http.js
+++ b/browser/http.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var XHR = require('./xhr')
-var url = require('url')
 var core = require('reducers/core'),
     convert = core.convert,
     accumulated = core.accumulated, end = core.end, error = core.error,
@@ -79,20 +78,18 @@ function readChunk(xhr, position) {
 }
 
 function Request(options) {
+  if (!options.uri) throw new Error('Requests require a url');
+  this.uri = options.uri;
+
   this.method = options.method ? options.method.toUpperCase() : 'GET'
-  this.headers = options.headers || null
-  this.protocol = options.protocol || 'http:'
-  this.host = options.host
-  this.port = options.port || null
-  this.path = options.path || '/'
-  this.hash = options.hash || ''
-  this.query = options.query || ''
-  this.body = options.body || ''
-  this.type = options.type || null
-  this.mimeType = options.mimeType || null
-  this.credentials = options.credentials || null
-  this.timeout = options.timeout || null
-  this.uri = options.uri || url.format(options)
+
+  var keys = [
+    'type', 'headers', 'mimeType', 'credentials', 'timeout', 'body'
+  ]
+
+  for (var i = 0; i < keys.length; i++) {
+    this[keys[i]] = (options[keys[i]] || null)    
+  }
 }
 connect.define(Request, function(request) {
   var uri = request.uri

--- a/browser/http.js
+++ b/browser/http.js
@@ -78,8 +78,8 @@ function readChunk(xhr, position) {
 }
 
 function Request(options) {
-  if (!options.uri) throw new Error('Requests require a url');
-  this.uri = options.uri;
+  if (!options.url) throw new Error('Requests require a url');
+  this.url = options.url;
 
   this.method = options.method ? options.method.toUpperCase() : 'GET'
 
@@ -92,7 +92,7 @@ function Request(options) {
   }
 }
 connect.define(Request, function(request) {
-  var uri = request.uri
+  var url = request.url
   var method = request.method
   var type = request.type
   var headers = request.headers
@@ -104,9 +104,9 @@ connect.define(Request, function(request) {
   return convert(request, function(self, next, state) {
     var xhr = new XHR()
     if (credentials)
-      xhr.open(method, uri, true, credentials.user, credentials.password)
+      xhr.open(method, url, true, credentials.user, credentials.password)
     else
-      xhr.open(request.method, request.uri, true)
+      xhr.open(request.method, request.url, true)
 
     if (type) xhr.responseType = type
     if (headers) setHeaders(xhr, headers)
@@ -148,7 +148,7 @@ connect.define(Request, function(request) {
 function request(options) { return new Request(options) }
 exports.request = request
 
-connect.define(String, function(uri) { return connect(request({ uri: uri })) })
+connect.define(String, function(url) { return connect(request({ url: url })) })
 exports.connect = connect
 
 function readHead(request) {


### PR DESCRIPTION
This pull request contains 2 changes:
## It removes the dependency on Node's `url` library.

Since this module is explicitly for browsers, I think it makes sense to avoid dependencies on Node core libraries. This is not a hard and fast rule, but more a rule of thumb.

Including Node dependencies means you must run the library through [browserify](https://github.com/substack/node-browserify). If we avoid dependencies on Node, it's possible to wrap the library in AMD or simply avoid modules altogether with minimal effort. Essentially, it's easier to maintain forks of different module flavors.

This seems a worthwhile goal to me. Some folks don't know how to use tools like `browserify`, others are stuck with a tool chain that prohibits it, others prefer AMD, etc.

Additionally, the cost of removing this dependency is low-to-nothing. The `url` library was being used to build URL strings from options objects. However, the url fragments it copied to the instance could not be counted on, since they would only appear on the `Request` instance if you had specified the URL via an object. If you specified the URL via a string, these properties would not appear. This made the interface for Request inconsistent.

Specifying URL with string is both the simpler and the more common case. It also removes the `url` lib dependency.
## It changes `uri` to `url`.

This is stylistic, but I think it's helpful. URI is easily confused with URL because `i`, `I`, and `l` are easily misread. Since `url` is the more common term, I think it makes sense to use it.

For prior art, see [jQuery.ajax](http://api.jquery.com/jQuery.ajax/), which uses `url` as a string property for requests.

I didn't see a test suite for `http`, so no tests have been added. Happy to write some if you like. I did smoke test the changes by hand.

Thanks!
