### PR TITLE
Add new line characters

### DIFF
--- a/debug/print.js
+++ b/debug/print.js
@@ -7,11 +7,11 @@ var isError = require("reducible/is-error")
 
 var PREFIX = "\u200B"
 var DELIMITER = PREFIX + " "
-var OPEN = PREFIX + "<---" 
+var OPEN = PREFIX + "<---"
 var CLOSE = PREFIX + "--->\n"
 var ERROR = PREFIX + "\u26A1 "
 
-var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER ]
+var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER, " ", "\n" ]
 
 var write = (function() {
   if (typeof(process) !== "undefined" &&
@@ -32,17 +32,18 @@ var write = (function() {
 
 function print(source, delimiter) {
   var open = false
-  
+
   delimiter = delimiter || DELIMITER
-  
+
   reduce(source, function reducePrintSource(value) {
-    if (!open) write(OPEN, DELIMITER)
+    if (!open) write(OPEN, delimiter)
     open = true
 
     if (value === end) write(CLOSE)
-    else if (isError(value)) write(ERROR, value, DELIMITER, CLOSE)
-    else write(value, DELIMITER)
+    else if (isError(value)) write(ERROR, value, delimiter, CLOSE)
+    else write(value, delimiter)
   })
+  return source
 }
 
 module.exports = print

--- a/debug/print.js
+++ b/debug/print.js
@@ -7,8 +7,8 @@ var isError = require("reducible/is-error")
 
 var PREFIX = "\u200B"
 var DELIMITER = PREFIX + " "
-var OPEN = PREFIX + "<---"
-var CLOSE = PREFIX + "--->\n"
+var OPEN = PREFIX + "< "
+var CLOSE = PREFIX + ">\n"
 var ERROR = PREFIX + "\u26A1 "
 
 var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER, " ", "\n" ]

--- a/debug/print.js
+++ b/debug/print.js
@@ -6,9 +6,9 @@ var end = require("reducible/end")
 var isError = require("reducible/is-error")
 
 var PREFIX = "\u200B"
-var DELIMITER = PREFIX + "\n"
-var OPEN = PREFIX + "<--------" + DELIMITER
-var CLOSE = PREFIX + "-------->" + DELIMITER
+var DELIMITER = PREFIX + " "
+var OPEN = PREFIX + "<---" 
+var CLOSE = PREFIX + "--->" 
 var ERROR = PREFIX + "\u26A1 "
 
 var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER ]
@@ -30,8 +30,11 @@ var write = (function() {
   }
 })()
 
-function print(source) {
+function print(source, delimiter) {
   var open = false
+  
+  delimiter = delimiter || DELIMITER
+  
   reduce(source, function reducePrintSource(value) {
     if (!open) write(OPEN)
     open = true

--- a/debug/print.js
+++ b/debug/print.js
@@ -6,10 +6,10 @@ var end = require("reducible/end")
 var isError = require("reducible/is-error")
 
 var PREFIX = "\u200B"
-var OPEN = PREFIX + "<--------"
-var CLOSE = PREFIX + "-------->"
-var ERROR = PREFIX + "\u26A1 "
 var DELIMITER = PREFIX + "\n"
+var OPEN = PREFIX + "<--------" + DELIMITER
+var CLOSE = PREFIX + "-------->" + DELIMITER
+var ERROR = PREFIX + "\u26A1 "
 
 var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER ]
 
@@ -33,10 +33,10 @@ var write = (function() {
 function print(source) {
   var open = false
   reduce(source, function reducePrintSource(value) {
-    if (!open) write(OPEN, DELIMITER)
+    if (!open) write(OPEN)
     open = true
 
-    if (value === end) write(CLOSE, DELIMITER)
+    if (value === end) write(CLOSE)
     else if (isError(value)) write(ERROR, value, DELIMITER, CLOSE)
     else write(value, DELIMITER)
   })

--- a/debug/print.js
+++ b/debug/print.js
@@ -6,10 +6,10 @@ var end = require("reducible/end")
 var isError = require("reducible/is-error")
 
 var PREFIX = "\u200B"
-var OPEN = PREFIX + "< "
-var CLOSE = PREFIX + ">\n"
+var OPEN = PREFIX + "<--------"
+var CLOSE = PREFIX + "-------->"
 var ERROR = PREFIX + "\u26A1 "
-var DELIMITER = PREFIX + " "
+var DELIMITER = PREFIX + "\n"
 
 var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER ]
 
@@ -33,10 +33,10 @@ var write = (function() {
 function print(source) {
   var open = false
   reduce(source, function reducePrintSource(value) {
-    if (!open) write(OPEN)
+    if (!open) write(OPEN, DELIMITER)
     open = true
 
-    if (value === end) write(CLOSE)
+    if (value === end) write(CLOSE, DELIMITER)
     else if (isError(value)) write(ERROR, value, DELIMITER, CLOSE)
     else write(value, DELIMITER)
   })

--- a/debug/print.js
+++ b/debug/print.js
@@ -7,7 +7,7 @@ var isError = require("reducible/is-error")
 
 var PREFIX = "\u200B"
 var DELIMITER = PREFIX + " "
-var OPEN = PREFIX + "< "
+var OPEN = PREFIX + "<"
 var CLOSE = PREFIX + ">\n"
 var ERROR = PREFIX + "\u26A1 "
 

--- a/debug/print.js
+++ b/debug/print.js
@@ -8,7 +8,7 @@ var isError = require("reducible/is-error")
 var PREFIX = "\u200B"
 var DELIMITER = PREFIX + " "
 var OPEN = PREFIX + "<---" 
-var CLOSE = PREFIX + "--->" 
+var CLOSE = PREFIX + "--->\n"
 var ERROR = PREFIX + "\u26A1 "
 
 var SPECIALS = [ OPEN, CLOSE, ERROR, DELIMITER ]
@@ -36,7 +36,7 @@ function print(source, delimiter) {
   delimiter = delimiter || DELIMITER
   
   reduce(source, function reducePrintSource(value) {
-    if (!open) write(OPEN)
+    if (!open) write(OPEN, DELIMITER)
     open = true
 
     if (value === end) write(CLOSE)


### PR DESCRIPTION
Changed print to be useful for printing larger values (entire objects)

So it now prints one value per line instead of all values in a single
line.

This is way more convenient for complex Reducibles and way less
convenient for [1, 2, 3]
